### PR TITLE
[FIX] avoid newproducts_without_company_id

### DIFF
--- a/energy_communities/models/product.py
+++ b/energy_communities/models/product.py
@@ -1,5 +1,8 @@
 from odoo import api, fields, models
 from odoo.http import request
+import logging
+
+logger = logging.getLogger(__name__)
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
@@ -36,3 +39,16 @@ class ProductTemplate(models.Model):
                 ]
             )
         return product_templates
+
+    @api.model
+    def create(self, vals):
+        if self.env.user not in (self.env.ref("base.user_root"),
+                                self.env.ref("base.user_admin"),
+                                self.env.ref("base.default_user"),
+                                self.env.ref("base.public_user"),
+                                self.env.ref("base.template_portal_user_id")):
+            if not vals.get('company_id', False):
+                vals['company_id'] = self.env.company.id
+
+        product = super(ProductTemplate, self).create(vals)
+        return product

--- a/energy_communities/models/product.py
+++ b/energy_communities/models/product.py
@@ -1,8 +1,5 @@
 from odoo import api, fields, models
 from odoo.http import request
-import logging
-
-logger = logging.getLogger(__name__)
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"


### PR DESCRIPTION
***In GitLab by @XavierBonetViura on Aug 2, 2023, 08:23 GMT+2:***

See this [card](https://trello.com/c/ra2PrBL6/197-en-crear-un-nou-producte-aquest-es-crea-sense-assignaci%C3%B3-de-company-i-per-tant-queda-a-la-vista-de-totes-les-ce): avoid when a user creates a new product it remains without company_id assigned

**Assignees:** @XavierBonetViura

**Reviewers:** @enricostano

**Approved by:** DaniilDigtyar

*Migrated from GitLab: https://git.coopdevs.org/coopdevs/comunitats-energetiques/odoo-ce/-/merge_requests/176*