### PR TITLE
FIX take out the initial full groups reset from roles definition

### DIFF
--- a/energy_communities/security/res_users_role_data.xml
+++ b/energy_communities/security/res_users_role_data.xml
@@ -28,7 +28,6 @@
         <field name="name">Energy Community Member</field>
         <field name="code">role_ce_member</field>
         <field name="implied_ids" eval="[
-                (5, 0, 0),
                 (4, ref('group_user')),
         ]"/>
     </record>
@@ -37,7 +36,6 @@
         <field name="name">Energy Community Administrator</field>
         <field name="code">role_ce_admin</field>
         <field name="implied_ids" eval="[
-               (5, 0, 0),
                (4, ref('group_admin')),
                (4, ref('sale.group_delivery_invoice_address')),
                (4, ref('account.group_account_invoice')),
@@ -61,7 +59,6 @@
         <field name="name">Energy Community Manager</field>
         <field name="code">role_ce_manager</field>
         <field name="implied_ids" eval="[
-               (5, 0, 0),
                (4, ref('group_admin')),
                (4, ref('sale.group_delivery_invoice_address')),
                (4, ref('account.group_account_invoice')),
@@ -85,7 +82,6 @@
         <field name="name">Coordinator Admin</field>
         <field name="code">role_coord_admin</field>
         <field name="implied_ids" eval="[
-               (5, 0, 0),
                (4, ref('group_admin')),
                (4, ref('sale.group_delivery_invoice_address')),
                (4, ref('account.group_account_invoice')),
@@ -109,7 +105,6 @@
         <field name="name">Coordinator Worker</field>
         <field name="code">role_coord_worker</field>
         <field name="implied_ids" eval="[
-               (5, 0, 0),
                (4, ref('group_user')),
                (4, ref('sale.group_delivery_invoice_address')),
                (4, ref('account.group_account_invoice')),
@@ -133,7 +128,6 @@
         <field name="name">Platform admin role</field>
         <field name="code">role_platform_admin</field>
         <field name="implied_ids" eval="[
-               (5, 0, 0),
                (4, ref('group_platform_manager')),
                (4, ref('group_admin')),
                (4, ref('base.group_erp_manager')),
@@ -161,7 +155,6 @@
         <field name="name">Internal User</field>
         <field name="code">role_internal_user</field>
         <field name="implied_ids" eval="[
-               (5, 0, 0),
                (4, ref('base.group_user')),
         ]"/>
     </record>


### PR DESCRIPTION
***In GitLab by @XavierBonetViura on Aug 4, 2023, 15:19 GMT+2:***

It is related to those cards:
https://trello.com/c/mUMGJSJl/77-error-de-permisos-oumaima
https://trello.com/c/LkCSbRdr/72-corregir-codi-de-la-mr-158-pel-re-seteig-del-groups-que-conformen-cada-role

Those [(5,0,0)] lines addesd on [MR#158](https://git.coopdevs.org/coopdevs/comunitats-energetiques/odoo-ce/-/merge_requests/158) are producing some inestable behaviour when `energy_comminities` module is upgraded:
- For some (?) reason, in PROD, if you force a `energy_community` module uPgrade from UI, And you look on Role `Comunity Energy Administrator` , some groups that was added MANUALLY (From UI) to this Role as `Administration / Access Rigths`, or some groups added FROM OTHER MODULES as `Energy Projects Energy Communities` as `Energy Project / Administrator` to this Role are NOT reset (deleted) after this `energy_comunities` upgrade. BUT, if instead you verify this behaviour (also in PROD) related to Role `Energy Community Manager`, in this case those 2 groups are dissapearing after each upgrade of 'energy_comminity'.
- When I reproduced the same scenarios described above in my LOCAl enviroment, the ([5,0,0]) line is DELETING those 2 groups in ALL ROLES.

So the best option is to **take out those [(5,0,0)]** lines in order to do not loose the groups added from `Energy Projects Energy Communities` on each `energy_community` module uPgrade, because it is now a real BAD think ( see https://trello.com/c/mUMGJSJl/77-error-de-permisos-oumaima )

If some groups added manually (by UI) to the roles are not deleted on each `energy_community` module uPgrade, it is not a issue and can be removed manually if needed. The only exception of this topic is the role 'type user portal' that at the moment of deploy of [MR#158](https://git.coopdevs.org/coopdevs/comunitats-energetiques/odoo-ce/-/merge_requests/158) we implement [5,0,0] in order to be REMOVED from the role `CE Member`.

**Assignees:** @XavierBonetViura

**Reviewers:** @enricostano

*Migrated from GitLab: https://git.coopdevs.org/coopdevs/comunitats-energetiques/odoo-ce/-/merge_requests/178*