### PR TITLE
[FIX] Credit notes must start with an R + journal code

### DIFF
--- a/energy_communities/__manifest__.py
+++ b/energy_communities/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Energy Community",
-    "version": "14.0.2.1.0",
+    "version": "14.0.2.1.1",
     "depends": [
         "account",
         "cooperator_account_banking_mandate",


### PR DESCRIPTION
***In GitLab by @enricostano on Oct 12, 2023, 18:20 GMT+2:***

Trello card: https://trello.com/c/IwiabyBh/308-factures-rectificatives-cs-no-afegeix-el-prefix-r

More context can be found here:
https://redirect.github.com/OCA/cooperative/issues/97

**Assignees:** @enricostano

**Reviewers:** DaniilDigtyar

**Approved by:** DaniilDigtyar

*Migrated from GitLab: https://git.coopdevs.org/coopdevs/comunitats-energetiques/odoo-ce/-/merge_requests/225*