### PR TITLE
If a user has already a role, don't launch a exception if we want to assign the same role again

### DIFF
--- a/energy_communities/models/res_users.py
+++ b/energy_communities/models/res_users.py
@@ -195,10 +195,11 @@ class ResUsers(models.Model):
                 )
 
                 if user_has_role_in_company:
-                    error = _(
+                    message = _(
                         "User with vat {} is already {} for the company {}"
                     ).format(self.login, user_role.code, company_id.name)
-                    raise ValidationError(error)
+                    logger.warning(message)
+                    self.partner_id.message_post(subject="[Warning]", body=message)
                 if role_is_not_available_for_user:
                     error = _(
                         "Role {} is not available for user with {} role. This role only allows {}"


### PR DESCRIPTION
In this pull request, we change the behavior when assigning roles in the process of creating a new user.
If a user has already a role, and we assign again the same role, instead of raise an exception, we write a warning log entry in the logfile and the same message to the partner chatter.

fix of: OP#1688